### PR TITLE
HP-1589 Feat/jupyter nb7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A "slim" build of jupyter notebook images
 ## Run locally
 
 ```
-docker-compose -f ./jupytersuperslim.yaml up
+docker compose -f ./jupytersuperslim.yaml up
 ```
 
-Then connect to http://localhost:9880/lw-workspace/proxy/
+Then connect to http://localhost:9888/lw-workspace/proxy/
 
 ## Deploy to hatchery
 

--- a/jupyter-superslim-rkernel/Dockerfile
+++ b/jupyter-superslim-rkernel/Dockerfile
@@ -22,9 +22,9 @@ USER root
 # (ARGS are in lower case to distinguish them from ENV)
 # Check https://github.com/conda-forge/miniforge/releases
 # Conda version
-ARG conda_version="4.10.3"
+ARG conda_version="24.3.0"
 # Miniforge installer patch version
-ARG miniforge_patch_number="3"
+ARG miniforge_patch_number="0"
 # Package Manager and Python implementation to use (https://github.com/conda-forge/miniforge)
 # - conda only: either Miniforge3 to use Python or Miniforge-pypy3 to use PyPy
 # - conda + mamba: either Mambaforge to use Python or Mambaforge-pypy3 to use PyPy
@@ -35,7 +35,7 @@ ARG miniforge_version="${conda_version}-${miniforge_patch_number}"
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update --yes && \
     apt-get install --yes --no-install-recommends \
     tini \
@@ -61,7 +61,7 @@ ENV CONDA_DIR=/opt/conda \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
-    R_BASE_VERSION=4.1.0
+    R_BASE_VERSION=4.3.3
 
 ENV PATH="${CONDA_DIR}/bin:${PATH}" \
     HOME="/home/${NB_USER}" \
@@ -97,7 +97,7 @@ RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
     fix-permissions "${CONDA_DIR}"
 
 USER ${NB_UID}
-ARG PYTHON_VERSION=default
+ARG PYTHON_VERSION=3.9
 
 # Install conda as jovyan and check the sha256 sum provided on the download site
 WORKDIR /tmp
@@ -123,6 +123,7 @@ RUN set -x && \
     conda list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \
     conda install --quiet --yes \
     "conda=${CONDA_VERSION}" \
+    "python=${PYTHON_VERSION}" \
     'pip' && \
     conda update --all --quiet --yes && \
     conda clean --all -f -y && \
@@ -138,7 +139,7 @@ RUN set -x && \
 # Correct permissions
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
-RUN conda install --quiet --yes \
+RUN conda install --quiet --yes python="${PYTHON_VERSION}"\
     'notebook' \
     'jupyterhub' \
     'jupyterlab' \
@@ -162,9 +163,8 @@ RUN conda install --quiet --yes \
     'r-gplots' \
     'r-gtools' \
     'r-catools' \
-    'jupyterhub=2' \
-    'jupyterhub-base=2' \
-    'jupyter_server=1' \
+    'jupyterhub-base' \
+    'jupyter_server' \
     && conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/jupyter-superslim-rkernel/Dockerfile
+++ b/jupyter-superslim-rkernel/Dockerfile
@@ -59,7 +59,7 @@ ENV CONDA_DIR=/opt/conda \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
-    R_BASE_VERSION=4.4.1
+    R_BASE_VERSION=4.3.3
 
 ENV PATH="${CONDA_DIR}/bin:${PATH}" \
     HOME="/home/${NB_USER}" \
@@ -69,11 +69,6 @@ ENV PATH="${CONDA_DIR}/bin:${PATH}" \
 # Copy a script that we will use to correct permissions after running certain commands
 COPY resources/scripts/fix-permissions /usr/local/bin/fix-permissions
 RUN chmod a+rx /usr/local/bin/fix-permissions
-
-# Use overrides.json file to change the default settings
-RUN mkdir -p /opt/conda/share/jupyter/lab/settings
-COPY resources/overrides.json /opt/conda/share/jupyter/lab/settings
-
 
 # Enable prompt color in the skeleton .bashrc before creating the default NB_USER
 # hadolint ignore=SC2016
@@ -130,6 +125,10 @@ RUN set -x && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 
+# Use overrides.json file to change the default settings
+RUN mkdir -p /opt/conda/share/jupyter/lab/settings
+COPY resources/overrides.json /opt/conda/share/jupyter/lab/settings
+
 # Install Jupyter Notebook, Lab, Hub and R packages
 # R packages including IRKernel which gets installed globally.
 # See https://github.com/rocker-org/rocker/blob/master/r-base/Dockerfile
@@ -138,7 +137,7 @@ RUN set -x && \
 # Correct permissions
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
-RUN conda install --quiet --yes python="${PYTHON_VERSION}"\
+RUN conda install --quiet --yes python="${PYTHON_VERSION}" \
     'notebook' \
     'jupyterhub' \
     'jupyterlab' \

--- a/jupyter-superslim-rkernel/Dockerfile
+++ b/jupyter-superslim-rkernel/Dockerfile
@@ -22,13 +22,11 @@ USER root
 # (ARGS are in lower case to distinguish them from ENV)
 # Check https://github.com/conda-forge/miniforge/releases
 # Conda version
-ARG conda_version="24.3.0"
+ARG conda_version="24.7.1"
 # Miniforge installer patch version
-ARG miniforge_patch_number="0"
+ARG miniforge_patch_number="2"
 # Package Manager and Python implementation to use (https://github.com/conda-forge/miniforge)
-# - conda only: either Miniforge3 to use Python or Miniforge-pypy3 to use PyPy
-# - conda + mamba: either Mambaforge to use Python or Mambaforge-pypy3 to use PyPy
-ARG miniforge_python="Mambaforge"
+ARG miniforge_python="Miniforge3"
 # Miniforge archive to install
 ARG miniforge_version="${conda_version}-${miniforge_patch_number}"
 
@@ -61,7 +59,7 @@ ENV CONDA_DIR=/opt/conda \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
-    R_BASE_VERSION=4.3.3
+    R_BASE_VERSION=4.4.1
 
 ENV PATH="${CONDA_DIR}/bin:${PATH}" \
     HOME="/home/${NB_USER}" \
@@ -102,7 +100,7 @@ ARG PYTHON_VERSION=3.9
 # Install conda as jovyan and check the sha256 sum provided on the download site
 WORKDIR /tmp
 
-# Prerequisites installation: conda, mamba, pip, tini
+# Prerequisites installation: conda, pip, tini
 RUN set -x && \
     # Miniforge installer
     miniforge_arch=$(uname -m) && \
@@ -117,6 +115,7 @@ RUN set -x && \
     rm "${miniforge_installer}" && \
     # Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
     echo "conda ${CONDA_VERSION}" >> "${CONDA_DIR}/conda-meta/pinned" && \
+    conda update -n base -c defaults conda && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
     if [[ "${PYTHON_VERSION}" != "default" ]]; then conda install --yes python="${PYTHON_VERSION}"; fi && \

--- a/jupyter-superslim-rkernel/jupytersuperslimrkernel.yaml
+++ b/jupyter-superslim-rkernel/jupytersuperslimrkernel.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
    webapp:
-      image: "jupyter-ssr"
+      image: "quay.io/cdis/jupyter-superslim-rkernel:latest"
       volumes:
          - ./data-volume:/data
          - ./user-volume:/home/jovyan/pd

--- a/jupyter-superslim-rkernel/jupytersuperslimrkernel.yaml
+++ b/jupyter-superslim-rkernel/jupytersuperslimrkernel.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
    webapp:
-      image: "quay.io/cdis/jupyter-superslim-rkernel:latest"
+      image: "jupyter-ssr"
       volumes:
          - ./data-volume:/data
          - ./user-volume:/home/jovyan/pd

--- a/jupyter-superslim-rkernel/requirements.txt
+++ b/jupyter-superslim-rkernel/requirements.txt
@@ -1,4 +1,4 @@
-gen3==4.17.2
+gen3
 cdiserrors
 pandas
 numpy

--- a/jupyter-superslim-rkernel/requirements.txt
+++ b/jupyter-superslim-rkernel/requirements.txt
@@ -1,10 +1,10 @@
-gen3>=4.25.0
+gen3
 cdiserrors
 pandas
 numpy
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
 # begin jupyter plugins and utilities section
-# jupyterlab-lsp # not installing this now since it will cause some dependency conflicts for the latest version of gen3sdk and jupyterlab
+jupyterlab-lsp
 jupyterlab-search-replace
 jupyterlab-git
 jupyter_server_ydoc

--- a/jupyter-superslim-rkernel/requirements.txt
+++ b/jupyter-superslim-rkernel/requirements.txt
@@ -1,4 +1,4 @@
-gen3
+gen3>=4.25.1
 cdiserrors
 pandas
 numpy

--- a/jupyter-superslim-rkernel/requirements.txt
+++ b/jupyter-superslim-rkernel/requirements.txt
@@ -4,6 +4,7 @@ pandas
 numpy
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
 # begin jupyter plugins and utilities section
+jupyter-lsp
 jupyterlab-lsp
 jupyterlab-search-replace
 jupyterlab-git

--- a/jupyter-superslim-rkernel/requirements.txt
+++ b/jupyter-superslim-rkernel/requirements.txt
@@ -1,6 +1,15 @@
-gen3>=4.25.1
+gen3>=4.25.0
 cdiserrors
 pandas
 numpy
-jupyter_server_ydoc
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
+# begin jupyter plugins and utilities section
+# jupyterlab-lsp # not installing this now since it will cause some dependency conflicts for the latest version of gen3sdk and jupyterlab
+jupyterlab-search-replace
+jupyterlab-git
+jupyter_server_ydoc
+altair[all]
+lckr_jupyterlab_variableinspector
+ripgrep
+frictionless
+# end jupyter plugins and utilities section

--- a/jupyter-superslim/Dockerfile
+++ b/jupyter-superslim/Dockerfile
@@ -138,6 +138,7 @@ COPY resources/overrides.json /opt/conda/share/jupyter/lab/settings
 RUN conda install --quiet --yes python="${PYTHON_VERSION}" \
     'notebook' \
     'jupyterhub' \
+    'jupyterlab' \
     'jupyterhub-base' \
     'jupyter_server' \
     && conda clean --all -f -y && \

--- a/jupyter-superslim/Dockerfile
+++ b/jupyter-superslim/Dockerfile
@@ -22,9 +22,9 @@ USER root
 # (ARGS are in lower case to distinguish them from ENV)
 # Check https://github.com/conda-forge/miniforge/releases
 # Conda version
-ARG conda_version="4.10.3"
+ARG conda_version="24.3.0"
 # Miniforge installer patch version
-ARG miniforge_patch_number="3"
+ARG miniforge_patch_number="0"
 # Package Manager and Python implementation to use (https://github.com/conda-forge/miniforge)
 # - conda only: either Miniforge3 to use Python or Miniforge-pypy3 to use PyPy
 # - conda + mamba: either Mambaforge to use Python or Mambaforge-pypy3 to use PyPy
@@ -35,7 +35,7 @@ ARG miniforge_version="${conda_version}-${miniforge_patch_number}"
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update --yes && \
     apt-get install --yes --no-install-recommends \
     tini \
@@ -91,7 +91,7 @@ RUN echo "auth requisite pam_deny.so" >> /etc/pam.d/su && \
     fix-permissions "${CONDA_DIR}"
 
 USER ${NB_UID}
-ARG PYTHON_VERSION=default
+ARG PYTHON_VERSION=3.9
 
 
 # Install conda as jovyan and check the sha256 sum provided on the download site
@@ -118,6 +118,7 @@ RUN set -x && \
     conda list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \
     conda install --quiet --yes \
     "conda=${CONDA_VERSION}" \
+    "python=${PYTHON_VERSION}" \
     'pip' && \
     conda update --all --quiet --yes && \
     conda clean --all -f -y && \
@@ -135,13 +136,12 @@ COPY resources/overrides.json /opt/conda/share/jupyter/lab/settings
 # Correct permissions
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
-RUN conda install --quiet --yes \
+RUN conda install --quiet --yes python="${PYTHON_VERSION}" \
     'notebook' \
     'jupyterhub' \
     'jupyterlab' \
-    'jupyterhub=2' \
-    'jupyterhub-base=2' \
-    'jupyter_server=1' \
+    'jupyterhub-base' \
+    'jupyter_server' \
     && conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/jupyter-superslim/Dockerfile
+++ b/jupyter-superslim/Dockerfile
@@ -138,7 +138,6 @@ COPY resources/overrides.json /opt/conda/share/jupyter/lab/settings
 RUN conda install --quiet --yes python="${PYTHON_VERSION}" \
     'notebook' \
     'jupyterhub' \
-    'jupyterlab' \
     'jupyterhub-base' \
     'jupyter_server' \
     && conda clean --all -f -y && \

--- a/jupyter-superslim/Dockerfile
+++ b/jupyter-superslim/Dockerfile
@@ -22,13 +22,11 @@ USER root
 # (ARGS are in lower case to distinguish them from ENV)
 # Check https://github.com/conda-forge/miniforge/releases
 # Conda version
-ARG conda_version="24.3.0"
+ARG conda_version="24.7.1"
 # Miniforge installer patch version
-ARG miniforge_patch_number="0"
+ARG miniforge_patch_number="2"
 # Package Manager and Python implementation to use (https://github.com/conda-forge/miniforge)
-# - conda only: either Miniforge3 to use Python or Miniforge-pypy3 to use PyPy
-# - conda + mamba: either Mambaforge to use Python or Mambaforge-pypy3 to use PyPy
-ARG miniforge_python="Mambaforge"
+ARG miniforge_python="Miniforge3"
 # Miniforge archive to install
 ARG miniforge_version="${conda_version}-${miniforge_patch_number}"
 
@@ -97,7 +95,7 @@ ARG PYTHON_VERSION=3.9
 # Install conda as jovyan and check the sha256 sum provided on the download site
 WORKDIR /tmp
 
-# Prerequisites installation: conda, mamba, pip, tini
+# Prerequisites installation: conda, pip, tini
 RUN set -x && \
     # Miniforge installer
     miniforge_arch=$(uname -m) && \
@@ -112,6 +110,7 @@ RUN set -x && \
     rm "${miniforge_installer}" && \
     # Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
     echo "conda ${CONDA_VERSION}" >> "${CONDA_DIR}/conda-meta/pinned" && \
+    conda update -n base -c defaults conda && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
     if [[ "${PYTHON_VERSION}" != "default" ]]; then conda install --yes python="${PYTHON_VERSION}"; fi && \

--- a/jupyter-superslim/requirements.txt
+++ b/jupyter-superslim/requirements.txt
@@ -13,3 +13,4 @@ lckr_jupyterlab_variableinspector
 ripgrep
 frictionless
 # end jupyter plugins and utilities section
+jupyterlab>=4.2.0 # install jupyterlab here to make sure it doesn't get downgraded

--- a/jupyter-superslim/requirements.txt
+++ b/jupyter-superslim/requirements.txt
@@ -1,4 +1,4 @@
-gen3==4.17.2
+gen3
 cdiserrors
 pandas
 numpy

--- a/jupyter-superslim/requirements.txt
+++ b/jupyter-superslim/requirements.txt
@@ -1,11 +1,11 @@
-gen3
+gen3>=4.25.0
 cdiserrors
 pandas
 numpy
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 # begin jupyter plugins and utilities section
-jupyterlab-lsp
+# jupyterlab-lsp # not installing this now since it will cause some dependency conflicts for the latest version of gen3sdk and jupyterlab
 jupyterlab-search-replace
 jupyterlab-git
 altair[all]
@@ -13,4 +13,3 @@ lckr_jupyterlab_variableinspector
 ripgrep
 frictionless
 # end jupyter plugins and utilities section
-jupyterlab>=4.2.0 # install jupyterlab here to make sure it doesn't get downgraded

--- a/jupyter-superslim/requirements.txt
+++ b/jupyter-superslim/requirements.txt
@@ -2,6 +2,12 @@ gen3>=4.25.1
 cdiserrors
 pandas
 numpy
+# begin of desired Jupyter plugins
 jupyter_server_ydoc
+jupyterlab-git
+jupyterlab-search-replace
+lckr-jupyterlab-variableinspector
+altair
+# end of desired Jupyter plugins
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/jupyter-superslim/requirements.txt
+++ b/jupyter-superslim/requirements.txt
@@ -1,11 +1,11 @@
-gen3>=4.25.0
+gen3
 cdiserrors
 pandas
 numpy
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 # begin jupyter plugins and utilities section
-# jupyterlab-lsp # not installing this now since it will cause some dependency conflicts for the latest version of gen3sdk and jupyterlab
+jupyterlab-lsp
 jupyterlab-search-replace
 jupyterlab-git
 altair[all]

--- a/jupyter-superslim/requirements.txt
+++ b/jupyter-superslim/requirements.txt
@@ -1,4 +1,4 @@
-gen3
+gen3>=4.25.1
 cdiserrors
 pandas
 numpy

--- a/jupyter-superslim/requirements.txt
+++ b/jupyter-superslim/requirements.txt
@@ -5,6 +5,7 @@ numpy
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 # begin jupyter plugins and utilities section
+jupyter-lsp
 jupyterlab-lsp
 jupyterlab-search-replace
 jupyterlab-git

--- a/jupyter-superslim/requirements.txt
+++ b/jupyter-superslim/requirements.txt
@@ -1,13 +1,15 @@
-gen3>=4.25.1
+gen3
 cdiserrors
 pandas
 numpy
-# begin of desired Jupyter plugins
-jupyter_server_ydoc
-jupyterlab-git
-jupyterlab-search-replace
-lckr-jupyterlab-variableinspector
-altair
-# end of desired Jupyter plugins
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+# begin jupyter plugins and utilities section
+jupyterlab-lsp
+jupyterlab-search-replace
+jupyterlab-git
+altair[all]
+lckr_jupyterlab_variableinspector
+ripgrep
+frictionless
+# end jupyter plugins and utilities section


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/HP-1589

Update Jupyter workspace base iamge to Jupyter notebook v7, Jupyterhub v5 and Jupyterlab v4 

### Dependency updates
- Jupyter notebook to `7.2.2`
- Jupyterhub to `5.2.0`
- Jupyterlab to `4.2.5`
- Gen3SDK to `4.25.4`
- Frictionless to `5.18.0`
- ripgrep to `14.1.0`
- jupyterlab-git to `0.50.1`
- jupyter-lsp to `2.2.5`
- jupyterlab-search-replace to `1.1.0`
- lckr-jupyterlab-variableinspector to `3.2.4`
- altair to `5.4.1`
- vl-convert-python to `1.7.0`

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
